### PR TITLE
model: add Time field to Reference

### DIFF
--- a/model/kallax.go
+++ b/model/kallax.go
@@ -1038,6 +1038,7 @@ type schemaRepositoryReferences struct {
 	Hash      kallax.SchemaField
 	Init      kallax.SchemaField
 	Roots     kallax.SchemaField
+	Time      kallax.SchemaField
 }
 
 func (s *schemaRepositoryReferences) At(n int) *schemaRepositoryReferences {
@@ -1049,6 +1050,7 @@ func (s *schemaRepositoryReferences) At(n int) *schemaRepositoryReferences {
 		Hash:            kallax.NewJSONSchemaArray("_references", fmt.Sprint(n), "Hash"),
 		Init:            kallax.NewJSONSchemaArray("_references", fmt.Sprint(n), "Init"),
 		Roots:           kallax.NewJSONSchemaArray("_references", fmt.Sprint(n), "Roots"),
+		Time:            kallax.NewJSONSchemaKey(kallax.JSONAny, "_references", fmt.Sprint(n), "Time"),
 	}
 }
 
@@ -1121,6 +1123,7 @@ var Schema = &schema{
 			Hash:            kallax.NewJSONSchemaArray("_references", "Hash"),
 			Init:            kallax.NewJSONSchemaArray("_references", "Init"),
 			Roots:           kallax.NewJSONSchemaArray("_references", "Roots"),
+			Time:            kallax.NewJSONSchemaKey(kallax.JSONAny, "_references", "Time"),
 		},
 	},
 }

--- a/model/reference.go
+++ b/model/reference.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"time"
+
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-kallax.v1"
 )
@@ -17,6 +19,8 @@ type Reference struct {
 	// Roots is a slice of the hashes of all root commits reachable from
 	// this reference.
 	Roots []SHA1
+	// Time is the time of the commit this reference points too.
+	Time time.Time
 }
 
 func (r *Reference) GitReference() *plumbing.Reference {


### PR DESCRIPTION
We had a per-repository LastCommitAt, but no per-reference
time. Here we add it per reference, which is more informative
and eases the logic in borges.