### PR TITLE
copier: fix override siva file on remote fs

### DIFF
--- a/repository/copier.go
+++ b/repository/copier.go
@@ -114,6 +114,19 @@ func (c *HDFSCopier) CopyToRemote(src, dst string, localFs billy.Filesystem) (er
 		return err
 	}
 
+	// TODO to avoid this, we should implement a 'truncate' flag in 'client.Create' method
+	_, err = c.client.Stat(p)
+	if err == nil {
+		err = c.client.Remove(p)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
 	rf, err := c.client.Create(p)
 	if err != nil {
 		return err

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -228,6 +228,22 @@ func testRootedTransactioner(t *testing.T, s RootedTransactioner) {
 	_, err = r3.Reference(refName1, false)
 	require.NoError(err)
 	require.NoError(tx3.Rollback())
+
+	// begin tx4
+	tx4, err := s.Begin(h1)
+	require.NoError(err)
+	require.NotNil(tx4)
+	r4, err := git.Open(tx4.Storer(), nil)
+	require.NoError(err)
+
+	// tx4 -> create ref4
+	refName4 := plumbing.ReferenceName("ref4")
+	err = r4.Storer.SetReference(plumbing.NewSymbolicReference(refName4, refName4))
+	require.NoError(err)
+
+	// commit tx4
+	err = tx4.Commit()
+	require.NoError(err)
 }
 
 type fsPair struct {


### PR DESCRIPTION
- Added a test to check if copier implementation is overriding the remote siva file with new changes.
- Fix hdfs copier to check if the file already exists and delete it before upload the new version.
- Added a todo comment to implement 'truncate' flag in the hdfs client library on Create.