### PR TITLE
added tag split_words to containerConfig struct

### DIFF
--- a/container.go
+++ b/container.go
@@ -20,9 +20,9 @@ const transactionerLocalDir = "transactioner"
 
 type containerConfig struct {
 	configurable.BasicConfiguration
-	TempDir             string `default:"/tmp/sourced"`
+	TempDir             string `default:"/tmp/sourced" split_words:"true"`
 	Broker              string `default:"amqp://localhost:5672"`
-	RootRepositoriesDir string `default:"/tmp/root-repositories"`
+	RootRepositoriesDir string `default:"/tmp/root-repositories" split_words:"true"`
 	Locking             string `default:"local:"`
 	HDFS                string `default:""`
 }


### PR DESCRIPTION
This PR solves issue https://github.com/src-d/core-retrieval/issues/31 and it must be merged after PR https://github.com/src-d/framework/pull/30 is merged.