### PR TITLE
provide a more meaningful error messages when db is not available

### DIFF
--- a/test/suite.go
+++ b/test/suite.go
@@ -22,22 +22,25 @@ type Suite struct {
 }
 
 func (s *Suite) Setup() {
+	require := s.Require()
 	s.dbName = fmt.Sprintf("db_%d", time.Now().UnixNano())
 	db, err := database.Default()
-	s.NoError(err)
+	require.NoError(err, "can't get default database")
+
+	require.NoError(db.Ping(), "unable to connect to the database")
 
 	_, err = db.Exec("CREATE DATABASE " + s.dbName)
-	s.NoError(err)
-	s.NoError(db.Close())
+	require.NoError(err, "can't create database %s", s.dbName)
+	s.NoError(db.Close(), "can't close database conn")
 
 	s.DB, err = database.Default(database.WithName(s.dbName))
-	s.NoError(err)
+	require.NoError(err, "can't get default database with name %s", s.dbName)
 
 	bytes, err := ioutil.ReadFile(schemaPath)
-	s.NoError(err)
+	require.NoError(err, "can't read schema file")
 
 	_, err = s.DB.Exec(string(bytes))
-	s.NoError(err)
+	require.NoError(err, "can't create database schema")
 }
 
 func (s *Suite) TearDown() {


### PR DESCRIPTION
Now any DB-related errors provide more meaningful error messages and stop the execution of the tests, which prevents nil pointer dereferences and such.

Fixes https://github.com/src-d/borges/issues/119 and any other repo using the test suite in this package.