### PR TITLE
go-git config now has URLs instead of URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   global:
     - DBUSER=postgres DBPASS=
   matrix:
-    - HADOOP_VERSION=2.7.2
+    - HADOOP_VERSION=2.7.4
     - HADOOP_VERSION=2.8.1
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8.1
+  - 1.9
   - tip
 
 go_import_path: gopkg.in/src-d/core-retrieval.v0

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -124,7 +124,7 @@ func testWithRealRepository(t *testing.T, s RootedTransactioner) {
 	r, err := git.Open(tx.Storer(), nil)
 	require.NoError(err)
 	_, err = r.CreateRemote(&config.RemoteConfig{
-		URL:  f.Worktree().Root(),
+		URLs: []string{f.Worktree().Root()},
 		Name: git.DefaultRemoteName,
 	})
 	require.NoError(err)

--- a/setup_hdfs.sh
+++ b/setup_hdfs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # TODO allow to test with more than one hadoop version if needed
-HADOOP_VERSION=${HADOOP_VERSION-"2.7.2"}
+HADOOP_VERSION=${HADOOP_VERSION-"2.7.4"}
 
 HADOOP_HOME="/tmp/hadoop-$HADOOP_VERSION"
 NN_PORT="9000"


### PR DESCRIPTION
go-git `config.RemoteConfig` structure has changed. This change is only needed for tests.