### PR TITLE
Add support for bucketed directories

### DIFF
--- a/container.go
+++ b/container.go
@@ -25,6 +25,7 @@ type containerConfig struct {
 	RootRepositoriesDir string `default:"/tmp/root-repositories" split_words:"true"`
 	Locking             string `default:"local:"`
 	HDFS                string `default:""`
+	BucketSize          int    `default:0`
 }
 
 var config = &containerConfig{}
@@ -135,9 +136,11 @@ func RootedTransactioner() repository.RootedTransactioner {
 
 		var copier repository.Copier
 		if config.HDFS == "" {
-			copier = repository.NewLocalCopier(osfs.New(config.RootRepositoriesDir))
+			copier = repository.NewLocalCopier(
+				osfs.New(config.RootRepositoriesDir), config.BucketSize)
 		} else {
-			copier = repository.NewHDFSCopier(config.HDFS, config.RootRepositoriesDir)
+			copier = repository.NewHDFSCopier(
+				config.HDFS, config.RootRepositoriesDir, config.BucketSize)
 		}
 
 		container.RootedTransactioner =

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -68,12 +68,19 @@ func (s *FilesystemSuite) cleanUpTempDirectories() {
 
 func (s *FilesystemSuite) Test() {
 	fsPairs := []*fsPair{
-		{"mem to mem", NewLocalCopier(memfs.New()), memfs.New()},
-		{"mem to os", NewLocalCopier(memfs.New()), s.newFilesystem()},
-		{"os to mem", NewLocalCopier(s.newFilesystem()), memfs.New()},
-		{"os to os", NewLocalCopier(s.newFilesystem()), s.newFilesystem()},
-		{"os to HDFS", NewHDFSCopier(hdfsURL, s.newTempPath()), s.newFilesystem()},
-		{"mem to HDFS", NewHDFSCopier(hdfsURL, s.newTempPath()), memfs.New()},
+		{"mem to mem", NewLocalCopier(memfs.New(), 0), memfs.New()},
+		{"mem to os", NewLocalCopier(memfs.New(), 0), s.newFilesystem()},
+		{"os to mem", NewLocalCopier(s.newFilesystem(), 0), memfs.New()},
+		{"os to os", NewLocalCopier(s.newFilesystem(), 0), s.newFilesystem()},
+		{"os to HDFS", NewHDFSCopier(hdfsURL, s.newTempPath(), 0), s.newFilesystem()},
+		{"mem to HDFS", NewHDFSCopier(hdfsURL, s.newTempPath(), 0), memfs.New()},
+
+		{"mem to mem", NewLocalCopier(memfs.New(), 2), memfs.New()},
+		{"mem to os", NewLocalCopier(memfs.New(), 2), s.newFilesystem()},
+		{"os to mem", NewLocalCopier(s.newFilesystem(), 2), memfs.New()},
+		{"os to os", NewLocalCopier(s.newFilesystem(), 2), s.newFilesystem()},
+		{"os to HDFS", NewHDFSCopier(hdfsURL, s.newTempPath(), 2), s.newFilesystem()},
+		{"mem to HDFS", NewHDFSCopier(hdfsURL, s.newTempPath(), 2), memfs.New()},
 	}
 
 	for _, fsPair := range fsPairs {


### PR DESCRIPTION
This feature add support for environment variable `CONFIG_BUCKETSIZE` that tell the amount of characters used from the beginning of the file to create directories. By default it does not create directories.

Related to: https://github.com/src-d/borges/issues/180
