### PR TITLE
Add support for cleaning up temporary directory

### DIFF
--- a/container.go
+++ b/container.go
@@ -21,6 +21,7 @@ const transactionerLocalDir = "transactioner"
 type containerConfig struct {
 	configurable.BasicConfiguration
 	TempDir             string `default:"/tmp/sourced" split_words:"true"`
+	CleanTempDir        bool   `default:"false" split_words:"true"`
 	Broker              string `default:"amqp://localhost:5672"`
 	RootRepositoriesDir string `default:"/tmp/root-repositories" split_words:"true"`
 	Locking             string `default:"local:"`
@@ -95,6 +96,10 @@ func ModelRepositoryStore() *model.RepositoryStore {
 // temporary files. This directory is dedicated to the running application.
 func TemporaryFilesystem() billy.Filesystem {
 	if container.TempDirFilesystem == nil {
+		if config.CleanTempDir {
+			os.RemoveAll(config.TempDir)
+		}
+
 		if err := os.MkdirAll(config.TempDir, os.FileMode(0755)); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
If a borges process is stopped forcefully it leaves back its temporary
directories. Restarting the process several times will accumulate these
temporary directories and can lead to space or inode exhaustion.

A new environment variable is added to delete tmp dirs from old runs.

`CONFIG_CLEAN_TEMP_DIR`: set to `true` to delete old tmp dirs. By
default it is `false`.