### PR TITLE
Fixed rooted-repos' temp-dir

### DIFF
--- a/container.go
+++ b/container.go
@@ -20,13 +20,14 @@ const transactionerLocalDir = "transactioner"
 
 type containerConfig struct {
 	configurable.BasicConfiguration
-	TempDir             string `default:"/tmp/sourced" split_words:"true"`
-	CleanTempDir        bool   `default:"false" split_words:"true"`
-	Broker              string `default:"amqp://localhost:5672"`
-	RootRepositoriesDir string `default:"/tmp/root-repositories" split_words:"true"`
-	Locking             string `default:"local:"`
-	HDFS                string `default:""`
-	BucketSize          int    `default:0`
+	TempDir                 string `default:"/tmp/sourced" split_words:"true"`
+	CleanTempDir            bool   `default:"false" split_words:"true"`
+	Broker                  string `default:"amqp://localhost:5672"`
+	RootRepositoriesDir     string `default:"/tmp/root-repositories" split_words:"true"`
+	RootRepositoriesTempDir string `default:"/tmp/root-repositories-dot-copy" split_words:"true"`
+	Locking                 string `default:"local:"`
+	HDFS                    string `default:""`
+	BucketSize              int    `default:0`
 }
 
 var config = &containerConfig{}
@@ -145,7 +146,10 @@ func RootedTransactioner() repository.RootedTransactioner {
 				osfs.New(config.RootRepositoriesDir), config.BucketSize)
 		} else {
 			copier = repository.NewHDFSCopier(
-				config.HDFS, config.RootRepositoriesDir, config.TempDir, config.BucketSize)
+				config.HDFS,
+				config.RootRepositoriesDir,
+				config.RootRepositoriesTempDir,
+				config.BucketSize)
 		}
 
 		container.RootedTransactioner =


### PR DESCRIPTION
- Added new `CONFIG_ROOTED_REPOSITORIES_TEMP_DIR` var to set where the siva.copy files will be places. Until now, they were using the same path that `CONFIG_TEMP_DIR`

- Fixed var uses as argument when a HDFSCopier is created.

Signed-off-by: Manuel Carmona <manu.carmona90@gmail.com>