### PR TITLE
Change model repository status 'Private' by 'AuthReq'

### DIFF
--- a/model/repository.go
+++ b/model/repository.go
@@ -55,10 +55,10 @@ const (
 	// fetched. It could also mean that there was an error and the repository
 	// never finished fetching.
 	Fetching FetchStatus = "fetching"
-	// Private means the remote repository was found but required
-	// authentication and thus it cannot be processed without appropiate
-	// credentials.
-	Private FetchStatus = "private"
+	// AuthRequired means the remote repository returns an authentication required
+	// error when you try to fetch it. It doesn't mean that repository exists,
+	// but if so, it cannot be processed without appropiate credentials.
+	AuthRequired FetchStatus = "auth_req"
 )
 
 // Language represents a language name.


### PR DESCRIPTION
As explained in the source code comment, sometimes this errors is returned even when a repository doesn't exist.

Since we are using this status to tag those repositories when we get that error from it (in the same way we are using "not found"), I think is more accurate use "auth_req" to note the fact that isn't an "existent private repository" for sure and keep in mind this came from an error fetching it. 

Related to https://github.com/src-d/borges/pull/248