### PR TITLE
Update hadoop version in setup_hdfs.sh script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,14 @@ matrix:
   fast_finish: true
   allow_failures:
     - go: tip
-    - env: HADOOP_VERSION=2.8.1
+    - env: HADOOP_VERSION=2.8.3
 
 env:
   global:
     - DBUSER=postgres DBPASS=
   matrix:
-    - HADOOP_VERSION=2.7.4
-    - HADOOP_VERSION=2.8.1
+    - HADOOP_VERSION=2.7.5
+    - HADOOP_VERSION=2.8.3
 
 services:
   - docker

--- a/setup_hdfs.sh
+++ b/setup_hdfs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # TODO allow to test with more than one hadoop version if needed
-HADOOP_VERSION=${HADOOP_VERSION-"2.7.4"}
+HADOOP_VERSION=${HADOOP_VERSION-"2.7.5"}
 
 HADOOP_HOME="/tmp/hadoop-$HADOOP_VERSION"
 NN_PORT="9000"


### PR DESCRIPTION
Hadoop versions `2.7.4` and `2.8.1` are no longer available for download so it makes fail the CI.