### PR TITLE
repository: decouple fs logic from copier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.prof
 .ci
 Makefile.main
+build
+minicluster.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.9
+  - 1.9.x
+  - 1.10.x
   - tip
 
 go_import_path: gopkg.in/src-d/core-retrieval.v0
@@ -16,7 +17,7 @@ env:
   global:
     - DBUSER=postgres DBPASS=
   matrix:
-    - HADOOP_VERSION=2.7.5
+    - HADOOP_VERSION=2.7.6
     - HADOOP_VERSION=2.8.3
 
 services:

--- a/container.go
+++ b/container.go
@@ -140,22 +140,24 @@ func RootedTransactioner() repository.RootedTransactioner {
 			panic(err)
 		}
 
-		var copier repository.Copier
+		var remote repository.Fs
 		if config.HDFS == "" {
-			copier = repository.NewLocalCopier(
-				osfs.New(config.RootRepositoriesDir), config.BucketSize)
+			remote = repository.NewLocalFs(osfs.New(config.RootRepositoriesDir))
 		} else {
-			copier = repository.NewHDFSCopier(
+			remote = repository.NewHDFSFs(
 				config.HDFS,
 				config.RootRepositoriesDir,
 				config.RootRepositoriesTempDir,
-				config.BucketSize)
+			)
 		}
 
 		container.RootedTransactioner =
 			repository.NewSivaRootedTransactioner(
-				copier,
-				tmpFs,
+				repository.NewCopier(
+					tmpFs,
+					remote,
+					config.BucketSize,
+				),
 			)
 	}
 

--- a/repository/copier.go
+++ b/repository/copier.go
@@ -4,12 +4,332 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
+
+	"context"
 
 	"github.com/colinmarc/hdfs"
 	"gopkg.in/src-d/go-billy.v4"
 	errors "gopkg.in/src-d/go-errors.v0"
 )
+
+// Fs is a filesystem implementation that has some operations such as
+// opening files, opening file writers, renaming, etc.
+type Fs interface {
+	// Open a file reader.
+	Open(string) (io.ReadCloser, error)
+	// WriteTo a file. It returns a file writer.
+	WriteTo(string) (io.WriteCloser, error)
+	// Rename atomically a file from one path to another.
+	Rename(src, dst string) error
+	// DeleteIfExists deletes a file only if it exists.
+	DeleteIfExists(string) error
+	// Base returns the base path of the filesystem to write files to.
+	Base() string
+	// TempDir returns the base path for temporary directories.
+	TempDir() string
+}
+
+// Copier is in charge of copying files from a local filesystem to the remote
+// one and vice-versa. It can optionally bucket files on the remote filesystem.
+type Copier struct {
+	remote     Fs
+	local      *localFs
+	bucketSize int
+}
+
+// NewCopier creates a new copier.
+func NewCopier(local billy.Filesystem, remote Fs, bucketSize int) *Copier {
+	return &Copier{remote: remote, local: &localFs{local}, bucketSize: bucketSize}
+}
+
+// Local returns the local filesystem of the copier.
+func (c *Copier) Local() billy.Filesystem {
+	return c.local.Filesystem
+}
+
+// CopyToRemote copies a file from the local filesystem to the remote one.
+func (c *Copier) CopyToRemote(ctx context.Context, src, dst string) error {
+	dst = filepath.Join(
+		c.remote.Base(),
+		addBucketName(dst, c.bucketSize),
+	)
+	dstCopy := dst + ".copy"
+
+	lf, err := c.local.Open(filepath.Join(c.local.Base(), src))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	defer checkClose(lf, &err)
+
+	w, err := c.remote.WriteTo(dstCopy)
+	if err != nil {
+		return err
+	}
+
+	if err = copy(ctx, w, lf); err != nil {
+		_ = w.Close()
+		_ = c.remote.DeleteIfExists(dstCopy)
+		return err
+	}
+
+	if err = w.Close(); err != nil {
+		_ = c.remote.DeleteIfExists(dstCopy)
+		return err
+	}
+
+	err = c.remote.Rename(dstCopy, dst)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+// CopyFromRemote copies a file to the local filesystem from the remote one.
+func (c *Copier) CopyFromRemote(ctx context.Context, src, dst string) (err error) {
+	src = filepath.Join(
+		c.remote.Base(),
+		addBucketName(src, c.bucketSize),
+	)
+	rf, err := c.remote.Open(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer checkClose(rf, &err)
+
+	w, err := c.local.WriteTo(filepath.Join(c.local.Base(), dst))
+	if err != nil {
+		return err
+	}
+	defer checkClose(w, &err)
+
+	err = copy(ctx, w, rf)
+	return
+}
+
+type localFs struct {
+	billy.Filesystem
+}
+
+// NewLocalFs returns a local file system.
+func NewLocalFs(fs billy.Filesystem) Fs {
+	return &localFs{fs}
+}
+
+func (fs *localFs) Open(path string) (io.ReadCloser, error) {
+	return fs.Filesystem.Open(path)
+}
+
+func (fs *localFs) WriteTo(path string) (io.WriteCloser, error) {
+	return fs.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0644))
+}
+
+func (fs *localFs) DeleteIfExists(path string) error {
+	if _, err := fs.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	return fs.Remove(path)
+}
+
+func (fs *localFs) TempDir() string {
+	return os.TempDir()
+}
+
+func (fs *localFs) Base() string {
+	return "/"
+}
+
+type hdfsFs struct {
+	url     string
+	base    string
+	tmpBase string
+	client  *hdfs.Client
+}
+
+// NewHDFSFs returns a filesystem that can access a HDFS cluster.
+// URL is the hdfs connection URL and base is the base path to store all the files.
+// tmpBase is the path to store all temporary .copy files while copying, which defaults
+// to base if empty.
+func NewHDFSFs(URL, base, tmpBase string) Fs {
+	if tmpBase == "" {
+		tmpBase = base
+	}
+	return &hdfsFs{url: URL, base: base, tmpBase: tmpBase}
+}
+
+// HDFSNamenodeError is returned when there is a namenode error.
+var HDFSNamenodeError = errors.NewKind("HDFS namenode error")
+var errorsToCatchFromHDFS = []string{
+	"no available namenodes",
+	"org.apache.hadoop.hdfs.server.namenode.SafeModeException",
+}
+
+func (fs *hdfsFs) freeClient(err error) (wrapped error) {
+	wrapped = err
+	if err != nil {
+		for _, HDFSError := range errorsToCatchFromHDFS {
+			if strings.Contains(err.Error(), HDFSError) {
+				wrapped = HDFSNamenodeError.Wrap(err)
+				fs.client = nil
+				break
+			}
+		}
+	}
+
+	return
+}
+
+func (fs *hdfsFs) initializeClient() (err error) {
+	if fs.client != nil {
+		return
+	}
+
+	fs.client, err = hdfs.New(fs.url)
+	return
+}
+
+func (fs *hdfsFs) Open(path string) (r io.ReadCloser, err error) {
+	defer func() {
+		err = fs.freeClient(err)
+	}()
+
+	if err = fs.initializeClient(); err != nil {
+		return
+	}
+
+	r, err = fs.client.Open(path)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (fs *hdfsFs) WriteTo(path string) (w io.WriteCloser, err error) {
+	defer func() {
+		err = fs.freeClient(err)
+	}()
+
+	if err = fs.initializeClient(); err != nil {
+		return
+	}
+
+	if err = fs.client.MkdirAll(filepath.Dir(path), os.FileMode(0644)); err != nil {
+		return
+	}
+
+	if err = fs.DeleteIfExists(path); err != nil {
+		return
+	}
+
+	w, err = fs.client.Create(path)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (fs *hdfsFs) Rename(src, dst string) (err error) {
+	defer func() {
+		err = fs.freeClient(err)
+	}()
+
+	if err = fs.client.MkdirAll(filepath.Dir(dst), os.FileMode(0644)); err != nil {
+		return err
+	}
+
+	err = fs.client.Rename(src, dst)
+	return
+}
+
+func (fs *hdfsFs) DeleteIfExists(file string) (err error) {
+	defer func() {
+		err = fs.freeClient(err)
+	}()
+
+	if _, err = fs.client.Stat(file); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	if err = fs.client.Remove(file); err != nil {
+		return err
+	}
+
+	return
+}
+
+func (fs *hdfsFs) TempDir() string {
+	return fs.tmpBase
+}
+
+func (fs *hdfsFs) Base() string {
+	return fs.base
+}
+
+func checkClose(c io.Closer, err *error) {
+	if cerr := c.Close(); cerr != nil && *err == nil {
+		*err = cerr
+	}
+}
+
+const copySize = 64 * 1024
+
+// ErrCopyCancelled is returned when a copy is cancelled.
+var ErrCopyCancelled = errors.NewKind("copy was cancelled")
+
+func copy(ctx context.Context, dst io.Writer, src io.Reader) error {
+	buf := make([]byte, copySize)
+	var done bool
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ErrCopyCancelled.New()
+		default:
+		}
+
+		n, err := src.Read(buf)
+		if err != nil {
+			if err != io.EOF {
+				return err
+			}
+
+			done = true
+		}
+
+		if n > 0 {
+			nw, err := dst.Write(buf[0:n])
+			if err != nil {
+				return err
+			}
+
+			if n != nw {
+				return io.ErrShortWrite
+			}
+		}
+
+		if done {
+			return nil
+		}
+	}
+}
 
 // addBucketName prepends the bucket dir name to the file name. The number of
 // characters used for the directory are specified by bucketSize. A value of 0
@@ -23,216 +343,4 @@ func addBucketName(name string, bucketSize int) string {
 	}
 
 	return name
-}
-
-// Copier is in charge either to obtain a file from the Remote filesystem implementation,
-// or send it from local.
-type Copier interface {
-	CopyFromRemote(src, dst string, localFs billy.Filesystem) error
-	CopyToRemote(src, dst string, localFs billy.Filesystem) error
-}
-
-// NewLocalCopier returns a Copier using as a remote a Billy filesystem
-func NewLocalCopier(fs billy.Filesystem, bucket int) Copier {
-	return &LocalCopier{fs, bucket}
-}
-
-type LocalCopier struct {
-	fs         billy.Filesystem
-	bucketSize int
-}
-
-func (c *LocalCopier) CopyFromRemote(src, dst string, localFs billy.Filesystem) error {
-	bSrc := addBucketName(src, c.bucketSize)
-	return c.copyFile(c.fs, localFs, bSrc, dst)
-}
-
-func (c *LocalCopier) CopyToRemote(src, dst string, localFs billy.Filesystem) error {
-	bDst := addBucketName(dst, c.bucketSize)
-	return c.copyFile(localFs, c.fs, src, bDst)
-}
-
-func (c *LocalCopier) copyFile(fromFs, toFs billy.Filesystem, from, to string) (err error) {
-	src, err := fromFs.Open(from)
-	if os.IsNotExist(err) {
-		return nil
-	}
-
-	if err != nil {
-		return err
-	}
-	defer checkClose(src, &err)
-
-	dst, err := toFs.OpenFile(to, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0644))
-	if err != nil {
-		return err
-	}
-	defer checkClose(dst, &err)
-
-	_, err = io.Copy(dst, src)
-	return err
-}
-
-// NewHDFSCopier returns a copier using as a remote an HDFS cluster.
-// URL is the hdfs connection URL and base is the base path to store all the files.
-// tmpBase is the path to store all temporary .copy files while copying, which defaults
-// to base if empty.
-func NewHDFSCopier(URL, base, tmpBase string, bucket int) Copier {
-	if tmpBase == "" {
-		tmpBase = base
-	}
-	return &HDFSCopier{url: URL, base: base, tmpBase: tmpBase, bucketSize: bucket}
-}
-
-type HDFSCopier struct {
-	url        string
-	base       string
-	tmpBase    string
-	client     *hdfs.Client
-	bucketSize int
-}
-
-var HDFSNamenodeError = errors.NewKind("HDFS namenode error")
-var errorsToCatchFromHDFS = []string{
-	"no available namenodes",
-	"org.apache.hadoop.hdfs.server.namenode.SafeModeException",
-}
-
-func (c *HDFSCopier) freeClient(err error) (wrapped error) {
-	wrapped = err
-	if err != nil {
-		for _, HDFSError := range errorsToCatchFromHDFS {
-			if strings.Contains(err.Error(), HDFSError) {
-				wrapped = HDFSNamenodeError.Wrap(err)
-				c.client = nil
-				break
-			}
-		}
-	}
-
-	return
-}
-
-// CopyFromRemote copies the file from HDFS to the provided billy Filesystem. If the file exists locally is overridden.
-// If a writer is actually overriding the file on HDFS, we will able to read it, but a previous version of it.
-func (c *HDFSCopier) CopyFromRemote(src, dst string, localFs billy.Filesystem) (err error) {
-	defer func() {
-		err = c.freeClient(err)
-	}()
-
-	if err := c.initializeClient(); err != nil {
-		return err
-	}
-
-	bSrc := addBucketName(src, c.bucketSize)
-	rf, err := c.client.Open(path.Join(c.base, bSrc))
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	defer checkClose(rf, &err)
-
-	lf, err := localFs.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0644))
-	if err != nil {
-		return err
-	}
-	defer checkClose(lf, &err)
-
-	_, err = io.Copy(lf, rf)
-	return
-}
-
-func (c *HDFSCopier) deleteIfExists(file string) error {
-	if _, err := c.client.Stat(file); os.IsNotExist(err) {
-		return nil
-	} else if err != nil {
-		return err
-	}
-
-	return c.client.Remove(file)
-}
-
-// CopyToRemote copies from the provided billy Filesystem to HDFS. If the file exists on HDFS it will be overridden.
-// If other writer is actually copying the same file to HDFS this method will throw an error because the WORM principle
-// (Write Once Read Many).
-func (c *HDFSCopier) CopyToRemote(src, dst string, localFs billy.Filesystem) (err error) {
-	defer func() {
-		err = c.freeClient(err)
-	}()
-
-	bDst := addBucketName(dst, c.bucketSize)
-	p := path.Join(c.base, bDst)
-	if err := c.initializeClient(); err != nil {
-		return err
-	}
-
-	pCopy := path.Join(c.tmpBase, dst+".copy")
-
-	lf, err := localFs.Open(src)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	defer checkClose(lf, &err)
-
-	if err := c.client.MkdirAll(path.Dir(p), os.FileMode(0644)); err != nil {
-		return err
-	}
-
-	if err := c.client.MkdirAll(path.Dir(pCopy), os.FileMode(0644)); err != nil {
-		return err
-	}
-
-	// TODO to avoid this, we should implement a 'truncate' flag in 'client.Create' method
-	err = c.deleteIfExists(pCopy)
-	if err != nil {
-		return err
-	}
-
-	rf, err := c.client.Create(pCopy)
-	if err != nil {
-		return err
-	}
-
-	// Delete temporary file in case the process is stopped while copying
-	defer func() {
-		rf.Close()
-		c.deleteIfExists(pCopy)
-	}()
-
-	_, err = io.Copy(rf, lf)
-
-	checkClose(rf, &err)
-
-	if err != nil {
-		c.client.Remove(pCopy)
-		return err
-	}
-
-	err = c.client.Rename(pCopy, p)
-
-	if err != nil {
-		return err
-	}
-
-	return
-}
-
-func (c *HDFSCopier) initializeClient() (err error) {
-	if c.client != nil {
-		return
-	}
-	c.client, err = hdfs.New(c.url)
-
-	return
-}
-
-func checkClose(c io.Closer, err *error) {
-	if cerr := c.Close(); cerr != nil && *err == nil {
-		*err = cerr
-	}
 }

--- a/repository/copier_test.go
+++ b/repository/copier_test.go
@@ -1,0 +1,27 @@
+package repository
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopy(t *testing.T) {
+	require := require.New(t)
+	content := []byte{0, 1, 2, 3, 4, 5, 6, 7}
+	var buf bytes.Buffer
+
+	err := copy(context.TODO(), &buf, bytes.NewBuffer(content))
+	require.NoError(err)
+	require.Equal(content, buf.Bytes())
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	cancel()
+	buf.Reset()
+	err = copy(ctx, &buf, bytes.NewBuffer(content))
+	require.Error(err)
+	require.True(ErrCopyCancelled.Is(err))
+	require.Equal([]byte{}, buf.Bytes())
+}

--- a/setup_hdfs.sh
+++ b/setup_hdfs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # TODO allow to test with more than one hadoop version if needed
-HADOOP_VERSION=${HADOOP_VERSION-"2.7.5"}
+HADOOP_VERSION=${HADOOP_VERSION-"2.7.6"}
 
 HADOOP_HOME="/tmp/hadoop-$HADOOP_VERSION"
 NN_PORT="9000"


### PR DESCRIPTION
Closes #58

This commit introduces the decouple of fs logic from the copiers, that become a single copier.

Before we had several copiers, one per remote file system. This was problematic because some high-level logic could not be reused and forced us to write again and again the same logic.

Now, we have two pieces that together act as the old copiers.

- Filesystems: which are `hdfsFs` and `localFs` that fulfill a certain interface that `Copier` needs to copy from a fs to the other.
- Copier: which is no longer an interface, but a struct, that knows how to apply this high level logic of copying from fs A to fs B in the exact same way by using the contract defined by the `Fs` interface.

In addition to that, `CopyFromRemote` and `CopyToRemote` are cancellable now.